### PR TITLE
C1_W3 Enforce Version Fixes

### DIFF
--- a/C1_Browser-based-TF-JS/W3/assignment/C1_W3_Assignment.ipynb
+++ b/C1_Browser-based-TF-JS/W3/assignment/C1_W3_Assignment.ipynb
@@ -30,9 +30,9 @@
     "id": "YHK6DyunSbs4"
    },
    "source": [
-    '# Note: To complete this module and continue the course, you must have python 3.8.10 installed.\n',
-    'You can find it by visiting python.org and searching for Python 3.8.10\n',
-    'Or you can follow this link: https://www.python.org/downloads/release/python-3810/'
+    "# Note: To complete this module and continue the course, you must have python 3.8.10 installed.\n",
+    "## You can find it by visiting python.org and searching for Python 3.8.10\n",
+    "## Or you can follow this link: https://www.python.org/downloads/release/python-3810/"
    ]
   },
   {
@@ -42,18 +42,18 @@
    "outputs": [],
    "source": [
     "import sys\n"
-    "def assert_python_version():\n"
-    "    current_major = sys.version_info.major\n"
-    "    current_minor = sys.version_info.minor\n"
-    "    # Check for major version first\n"
-    "    if current_major < 3:\n"
-    "        return # Version is less than 3.0, so its less than 3.8\n"
-    "    if current_major > 3:\n"
-    "        raise AssertionError('Bad Major Version. Check you have python verson 3.8.10')\n"
-    "    # If major version is 3, check minor version\n"
-    "    if current_minor > 8:\n"
-    "        raise AssertionError('Bad Minor Version. Check that you have python 3.8.10')\n"
-    "    print('Python version check passed.')\n"
+    "def assert_python_version():\n",
+    "    current_major = sys.version_info.major\n",
+    "    current_minor = sys.version_info.minor\n",
+    "    # Check for major version first\n",
+    "    if current_major < 3:\n",
+    "        return # Version is less than 3.0, so its less than 3.8\n",
+    "    if current_major > 3:\n",
+    "        raise AssertionError('Bad Major Version. Check you have python verson 3.8.10')\n",
+    "    # If major version is 3, check minor version\n",
+    "    if current_minor > 8:\n",
+    "        raise AssertionError('Bad Minor Version. Check that you have python 3.8.10')\n",
+    "    print('Python version check passed.')\n",
     "assert_python_version()\n'"
    ]
   },
@@ -67,7 +67,6 @@
     '# Additionally, the following modules and versions must be used'
    ]
   },
-
   {
    "cell_type": "code",
    "execution_count": null,

--- a/C1_Browser-based-TF-JS/W3/assignment/C1_W3_Assignment.ipynb
+++ b/C1_Browser-based-TF-JS/W3/assignment/C1_W3_Assignment.ipynb
@@ -64,7 +64,7 @@
     "id": "YHK6DyunSbs4"
    },
    "source": [
-    '# Additionally, the following modules and versions must be used'
+    "# Additionally, the following modules and versions must be used"
    ]
   },
   {
@@ -72,14 +72,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [  
+   "source": [
     "%pip install tensorflow==2.2.0\n",
     "%pip install tensorflowjs==2.8.5\n",
     "%pip install tensorflow-estimator==2.2.0\n",
     "%pip install protobuf==3.12.2\n",
     "%pip uninstall numpy\n",
     "%pip install numpy==1.19.3\n",
-    "%pip install matplotlib==3.4.2\n" 
+    "%pip install matplotlib==3.4.2\n"
    ]
   },
   {

--- a/C1_Browser-based-TF-JS/W3/assignment/C1_W3_Assignment.ipynb
+++ b/C1_Browser-based-TF-JS/W3/assignment/C1_W3_Assignment.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n"
+    "import sys\n",
     "def assert_python_version():\n",
     "    current_major = sys.version_info.major\n",
     "    current_minor = sys.version_info.minor\n",
@@ -54,8 +54,8 @@
     "    if current_minor > 8:\n",
     "        raise AssertionError('Bad Minor Version. Check that you have python 3.8.10')\n",
     "    print('Python version check passed.')\n",
-    "assert_python_version()\n'"
-   ]
+    "assert_python_version()\n"
+]
   },
   {
    "cell_type": "markdown",

--- a/C1_Browser-based-TF-JS/W3/assignment/C1_W3_Assignment.ipynb
+++ b/C1_Browser-based-TF-JS/W3/assignment/C1_W3_Assignment.ipynb
@@ -23,6 +23,66 @@
     "# limitations under the License."
    ]
   },
+ {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "YHK6DyunSbs4"
+   },
+   "source": [
+    '# Note: To complete this module and continue the course, you must have python 3.8.10 installed.\n',
+    'You can find it by visiting python.org and searching for Python 3.8.10\n',
+    'Or you can follow this link: https://www.python.org/downloads/release/python-3810/'
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n"
+    "def assert_python_version():\n"
+    "    current_major = sys.version_info.major\n"
+    "    current_minor = sys.version_info.minor\n"
+    "    # Check for major version first\n"
+    "    if current_major < 3:\n"
+    "        return # Version is less than 3.0, so its less than 3.8\n"
+    "    if current_major > 3:\n"
+    "        raise AssertionError('Bad Major Version. Check you have python verson 3.8.10')\n"
+    "    # If major version is 3, check minor version\n"
+    "    if current_minor > 8:\n"
+    "        raise AssertionError('Bad Minor Version. Check that you have python 3.8.10')\n"
+    "    print('Python version check passed.')\n"
+    "assert_python_version()\n'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "YHK6DyunSbs4"
+   },
+   "source": [
+    '# Additionally, the following modules and versions must be used'
+   ]
+  },
+
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [  
+    "%pip install tensorflow==2.2.0\n",
+    "%pip install tensorflowjs==2.8.5\n",
+    "%pip install tensorflow-estimator==2.2.0\n",
+    "%pip install protobuf==3.12.2\n",
+    "%pip uninstall numpy\n",
+    "%pip install numpy==1.19.3\n",
+    "%pip install matplotlib==3.4.2\n" 
+   ]
+  },
   {
    "cell_type": "markdown",
    "metadata": {
@@ -54,24 +114,6 @@
     "In order to use the tensorflow.js converter we need to install `tensorflowjs`.\n",
     "\n",
     "**Note:** Use TensorFlow version 2.2.0 for this assignment. **Using a TensorFlow version >2.2.0 will result in failure of grading.**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install tensorflow==2.2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#!pip install tensorflowjs"
    ]
   },
   {


### PR DESCRIPTION
It it's current state, Main is not able to be completed or graded for C1_W3.  Modern python versions past 3.8.10 do not seem to work correctly for this project, so it will enforce that requirement along with the other package version requirements.